### PR TITLE
Improved performance / bug fixes

### DIFF
--- a/lib/collapse_diff.js
+++ b/lib/collapse_diff.js
@@ -3,26 +3,24 @@
   var fileContainers = document.querySelectorAll('#files .file');
 
   var bindToggler = function(elem) {
-    var actions = elem.querySelectorAll('.meta .actions')[0];
+    var actions = elem.querySelector('.meta .actions');
     var collapsed = false;
-    actions.innerHTML = butHtml + actions.innerHTML;
-    actions.getElementsByClassName('diff-collapse-button')[0].onclick = function(e) {
-      var diffTable = elem.getElementsByClassName('diff-table')[0];
+    actions.insertAdjacentHTML('afterbegin', butHtml);
+    actions.querySelector('.diff-collapse-button').addEventListener('click', function(e) {
+      var diffTable = elem.querySelector('table.file-diff, .diff-table');
       e.preventDefault();
-      if(collapsed) {
-        e.srcElement.innerHTML = 'Collapse';
-        diffTable.style.display = 'table';
-      }
-      else {
-        e.srcElement.innerHTML = 'Expand';
+      if (collapsed) {
+        e.target.textContent = 'Collapse';
+        diffTable.style.display = ''; // Restore old display: table
+      } else {
+        e.target.textContent = 'Expand';
         diffTable.style.display = 'none';
       }
       collapsed = !collapsed;
-    };
+    }, true);
   };
 
-  for(var i = 0; i < fileContainers.length; i++) {
+  for (var i = 0; i<fileContainers.length; ++i) {
     bindToggler(fileContainers[i]);
   }
-
 })();


### PR DESCRIPTION
Bug fixes:

`.diff-table` was not found in a pull request. `table.file-diff` did exists though.
Using both for optimal compatibility.

Instead of concatenation HTML, which has the potential side effect of disabling Github's functionality, I switched to `insertAdjacentHTML`.
