### PR TITLE
Save and load collapsed diffs with cookie

### DIFF
--- a/lib/collapse_diff.js
+++ b/lib/collapse_diff.js
@@ -16,7 +16,7 @@
     if(message) { message.style.display = 'block'; }
   };
 
-  var bindToggler = function(buttonContainer, tableToToggle, addPlaceHolder) {
+  var bindToggler = function(buttonContainer, tableToToggle, diffName, addPlaceHolder) {
     var messageDiv, button;
     if(!tableToToggle) { return; }
 
@@ -32,28 +32,60 @@
       }, true);
     }
 
-
     button.addEventListener('click', function(e) {
       e.preventDefault();
       if (button.textContent !== 'Collapse') {
         expand(button, tableToToggle, messageDiv);
+        collapsedDiffs.remove(diffName);
       } else {
         collapse(button, tableToToggle, messageDiv);
+        collapsedDiffs.add(diffName);
       }
     }, true);
+
+    if (collapsedDiffs.has(diffName)) collapse(button, tableToToggle, messageDiv);
+  };
+
+  var collapsedDiffs = {
+    diffs: (function() {
+      var collapsedDiffs = {};
+      var cookies = document.cookie.split(';');
+
+      for (var i = 0; i < cookies.length; ++i) {
+        var cookie = cookies[i].split('=');
+        if (cookie[0].trim() === "collapsedDiffs") {
+          var keys = decodeURIComponent(cookie[1].trim()).split(',');
+          for (var j = 0; j < keys.length; ++j) collapsedDiffs[keys[j]] = true;
+        }
+      }
+      return collapsedDiffs;
+    })(),
+
+    add: function(key) {
+      this.diffs[key] = true;
+      document.cookie = "collapsedDiffs=" + encodeURIComponent(Object.keys(this.diffs).join(','));
+    },
+    remove: function(key) {
+      delete this.diffs[key];
+      document.cookie = "collapsedDiffs=" + encodeURIComponent(Object.keys(this.diffs).join(','));
+    },
+    has: function(key) {
+      return this.diffs[key];
+    }
   };
 
   var fileContainers = document.querySelectorAll('#files .file');
   for (var i = 0; i < fileContainers.length; ++i) {
+    var filepath = fileContainers[i].querySelector('.meta .info .js-selectable-text').title;
     bindToggler(fileContainers[i].querySelector('.meta .actions'),
-      fileContainers[i].querySelector('table.file-diff, .diff-table'), true);
+      fileContainers[i].querySelector('table.file-diff, .diff-table'), filepath, true);
   }
 
   var discussions = document.querySelectorAll('.mini-discussion-bubble-action');
   for (var i = 0; i < discussions.length; ++i) {
     var buttonContainer = discussions[i].appendChild(document.createElement('div'));
     buttonContainer.style.cssText = 'float:right';
-    bindToggler(buttonContainer, discussions[i].nextElementSibling, false);
+    bindToggler(buttonContainer, discussions[i].nextElementSibling, "key-for-cookie", false);
   }
 
 })();


### PR DESCRIPTION
I am glad to find this extension! This extension is exactly what I wanted. But currently when we reload the PR page, all collapsed diffs will be expanded.

I've implemented save/load function with cookie. Now even when we reload the page, we can see same state which means collapsed diffs stay collapsed and expanded diffs stay expanded.
I used filename as a key for cookie. Cookie relies on page URL. So only if URL and filename are same, the plugin collapse diff automatically.
