### PR TITLE
Updating to match github's changed markup

### DIFF
--- a/lib/collapse_diff.js
+++ b/lib/collapse_diff.js
@@ -1,6 +1,6 @@
 (function() {
 
-  var butHtml = '<div class="button-group"><a href="#collapse_diff" style="margin-left: 5px" class="diff-collapse-button minibutton" rel="nofollow">Collapse</a></div>';
+  var butHtml = '<a href="#collapse_diff" style="margin-left: 5px" class="diff-collapse-button btn btn-sm" rel="nofollow">Collapse</a>';
   var collapsedHtml = '<div class="image diff-collapsed-message" style="display: none"><a href="#" class="expand-diff-link">Diff suppressed. Click to show.</a></div>';
 
   var expand = function(button, content, message) {
@@ -45,7 +45,7 @@
 
   var fileContainers = document.querySelectorAll('#files .file');
   for (var i = 0; i < fileContainers.length; ++i) {
-    bindToggler(fileContainers[i].querySelector('.meta .actions'),
+    bindToggler(fileContainers[i].querySelector('.file-actions'),
       fileContainers[i].querySelector('table.file-diff, .diff-table'), true);
   }
 


### PR DESCRIPTION
Was excited to see this functionality, but it doesn't work out of the box. Github has made small changes to their markup which breaks how the collapse/expand buttons are added. This should fix them.